### PR TITLE
fix cbind unit test failures

### DIFF
--- a/R/converters.R
+++ b/R/converters.R
@@ -532,7 +532,7 @@ jab2gg = function(jabba)
     {
       if (ncol(values(jabba$junctions))>0)
       {
-        ab.edges = as.data.table(cbind(ab.edges, values(jabba$junctions)[ab.edges$jid, ]))
+        ab.edges = cbind(ab.edges, as.data.table(values(jabba$junctions)[ab.edges$jid, ]))
         if (!is.null(ab.edges$cn))
           ab.edges[, cn := NULL] ## confilct with the cn inferred from adj
       }

--- a/R/eventCallers.R
+++ b/R/eventCallers.R
@@ -212,10 +212,10 @@ proximity = function(gg,
                dt[ , .(qid, sid, reldist, altdist, refdist)])
 
   if (ncol(values(query.og))>0)
-    meta = cbind(meta, values(query.og)[meta$qid, , drop = FALSE])
+    meta = cbind(meta, as.data.table(values(query.og)[meta$qid, , drop = FALSE]))
 
   if (ncol(values(subject.og))>0)
-    meta = cbind(meta, values(subject.og)[meta$sid, , drop = FALSE])
+    meta = cbind(meta, as.data.table(values(subject.og)[meta$sid, , drop = FALSE]))
 
   px = gW(snode.id = px$snode.id, graph = px$graph, meta = meta)
 


### PR DESCRIPTION
jab2gg and proximity break in R4 because of cbind([data.table], [DataFrame]). this fixes the broken unit tests