### PR TITLE
Itemize all when merging junctions

### DIFF
--- a/R/gGnome.R
+++ b/R/gGnome.R
@@ -9074,7 +9074,7 @@ merge = function(...) {
       out.grl = .cgrl(out.grl, right.grl) 
     }
 
-    names(values(out.grl)) = dedup(names(values(out.grl)))
+    names(values(out.grl)) = dedup(names(values(out.grl)), itemize.all = TRUE)
     Junction$new(out.grl)
   }
   else

--- a/R/utils.R
+++ b/R/utils.R
@@ -995,7 +995,9 @@ ra.merge = function(..., pad = 0, ignore.strand = FALSE){
     for (i in seq_along(nm)){
         mc2 = as.data.table(mcols(ra[[nm[i]]]))
         if (length(nm) > 1){
-            names(mc2) = paste0(names(mc2), '.', nm[i])
+            if (length(names(mc2)) > 0){
+                names(mc2) = paste0(names(mc2), '.', nm[i])
+            }
         }
         mc2[, tmp.ix := seq_len(.N)]
         mc = merge(

--- a/R/utils.R
+++ b/R/utils.R
@@ -993,11 +993,7 @@ ra.merge = function(..., pad = 0, ignore.strand = FALSE){
 
     mc = copy(seen.by)
     for (i in seq_along(nm)){
-        if (i>1){
-            suf = paste0(".", c(nm[i-1], nm[i]))
-        } else {
-            suf = c(".x", ".y")
-        }
+        suf = paste0(".", c(nm[i-1], nm[i]))
         mc = merge(
             copy(mc)[
               , tmp.ix := as.numeric(gsub("^([0-9]+)((,[0-9]+)?)$", "\\1", mc[[nm[i]]]))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1056,15 +1056,20 @@ dodo.call = function(FUN, args)
 #'
 #' @param x input vector to dedup
 #' @param suffix suffix separator to use before adding integer for dups in x
-#' @return length(x) vector of input + suffix separator + integer for dups and no suffix for "originals"
+#' @param itemize.all by default the first item will not have a suffix. If itemize.all is set to TRUE then all items (including the first item) will have a suffix added to them
+#' @return length(x) vector of input + suffix separator + integer for dups and no suffix for "originals" (unless itemize.all is set to TRUE and then all copies get a suffix)
 #' @author Marcin Imielinski
 #' @noRd
-dedup = function(x, suffix = '.')
+dedup = function(x, suffix = '.', itemize.all = FALSE)
 {
     dup = duplicated(x);
     udup = setdiff(unique(x[dup]), NA)
     udup.ix = lapply(udup, function(y) which(x==y))
-    udup.suffices = lapply(udup.ix, function(y) c('', paste(suffix, 2:length(y), sep = '')))
+    if (itemize.all){
+        udup.suffices = lapply(udup.ix, function(y) c(paste(suffix, 1:length(y), sep = '')))
+    } else {
+        udup.suffices = lapply(udup.ix, function(y) c('', paste(suffix, 2:length(y), sep = '')))
+    }
     out = x;
     out[unlist(udup.ix)] = paste(out[unlist(udup.ix)], unlist(udup.suffices), sep = '');
     return(out)

--- a/R/utils.R
+++ b/R/utils.R
@@ -993,14 +993,18 @@ ra.merge = function(..., pad = 0, ignore.strand = FALSE){
 
     mc = copy(seen.by)
     for (i in seq_along(nm)){
-        suf = paste0(".", c(nm[i-1], nm[i]))
+        mc2 = as.data.table(mcols(ra[[nm[i]]]))
+        if (length(nm) > 1){
+            names(mc2) = paste0(names(mc2), '.', nm[i])
+        }
+        mc2[, tmp.ix := seq_len(.N)]
         mc = merge(
             copy(mc)[
               , tmp.ix := as.numeric(gsub("^([0-9]+)((,[0-9]+)?)$", "\\1", mc[[nm[i]]]))
             ],
-            as.data.table(mcols(ra[[nm[i]]]))[, tmp.ix := seq_len(.N)],
-            by = "tmp.ix", all.x = TRUE,
-            suffixes = suf
+            mc2
+            ,
+            by = "tmp.ix", all.x = TRUE
         )
     }
     mc = mc[order(merged.ix)]

--- a/tests/testthat/test_gGnome_ops.R
+++ b/tests/testthat/test_gGnome_ops.R
@@ -685,6 +685,11 @@ test_that('gGnome tutorial', {
               novo = novobreak[, c()], anynameworks = bedpe[,c()], pad = 1e3)
   expect_equal(res$dt$seen.by.svaba[1] & !res$dt$seen.by.delly[1] & !res$dt$seen.by.novo[1] & !res$dt$seen.by.anynameworks[1], TRUE)
 
+  # test cartesian merging.
+  res = merge(svaba, delly, cartesian = TRUE, pad = 1e3)
+  # we expect the field query.id to map back to the junction in svaba
+  expect_equal(length(res[1] %&% svaba[res[1]$dt[, query.id]]), 1)
+
     ## can use both row and column subsetting on Junction metadata
   expect_equal(as.character(head(novobreak[1:2, 1:10])$dt$CHROM[1]), '10')
 

--- a/tests/testthat/test_gGnome_ops.R
+++ b/tests/testthat/test_gGnome_ops.R
@@ -685,6 +685,10 @@ test_that('gGnome tutorial', {
               novo = novobreak[, c()], anynameworks = bedpe[,c()], pad = 1e3)
   expect_equal(res$dt$seen.by.svaba[1] & !res$dt$seen.by.delly[1] & !res$dt$seen.by.novo[1] & !res$dt$seen.by.anynameworks[1], TRUE)
 
+  # merge with metadata
+  res = merge(svaba, delly, pad = 1e3)
+  expect_true('MATEID.ra1' %in% names(res$dt) & 'MATEID.ra2' %in% names(res$dt))
+
   # test cartesian merging.
   res = merge(svaba, delly, cartesian = TRUE, pad = 1e3)
   # we expect the field query.id to map back to the junction in svaba


### PR DESCRIPTION
There has been something about merge.Junction that I personally find unintuitive:
when merging, then metadata columns are aggregated where if all input objects had a field V1 then the value from the first sample will be in a field V1, the value from the second sample will be in V1.ra1, third sample in V1.ra2.

This pull request changes that behavior so that all duplicated fields (including the first one) will have a suffix (if fields are not duplicated then no suffix will be added).