### PR TITLE
Change loose end metadata

### DIFF
--- a/R/gGnome.R
+++ b/R/gGnome.R
@@ -730,7 +730,9 @@ gNode = R6::R6Class("gNode",
                         loose.fields.keep = intersect(names(mcols(l)), loose.fields)
                         l = l[, loose.fields.keep]
                         names(mcols(l)) = new.names[loose.fields.keep]
-                        l$orientation = 'left'
+                        if (length(l) > 0){
+                            l$orientation = 'left'
+                        }
                         return(l)
                       },
                       
@@ -752,7 +754,9 @@ gNode = R6::R6Class("gNode",
                         loose.fields.keep = intersect(names(mcols(l)), loose.fields)
                         l = l[, loose.fields.keep]
                         names(mcols(l)) = new.names[loose.fields.keep]
-                        l$orientation = 'right'
+                        if (length(l) > 0){
+                            l$orientation = 'right'
+                        }
                         return(l)
                       },
 

--- a/R/gGnome.R
+++ b/R/gGnome.R
@@ -166,7 +166,7 @@ gNode = R6::R6Class("gNode",
                       #'
                       #' Note: these replacement obey the orientation of the arguments.  So if the node to be replaced is flipped (- orientation with
                       #' respect to the reference, then it's "left" is to the right on the reference.  Similarly for walks whose first interval
-                      #' is flipped with respect to the reference, the left edges will be attached to the right of the node on the reference.
+                      #' is flipped with respect to the reference, the left edges will be attached to the right of the node on the reference.)
                       #' 
                       #' @param replacement  GRanges, GRangesList, or gWalk object whose length is the length(nodes)
                       #' @author Marcin Imielinski
@@ -275,7 +275,7 @@ gNode = R6::R6Class("gNode",
                       #'
                       #' Unlike the gGraph version of this function, this usage enables computation of clusters
                       #' based on a subset of nodes in the graph (i.e. ignoring certain nodes)
-                      #' while still marking the original graph (and leaving the excluded graph with an NA
+                      #' while still marking the original graph (and leaving the excluded graph with an NA)
                       #' value for "cluster"
                       #' 
                       #'
@@ -565,14 +565,13 @@ gNode = R6::R6Class("gNode",
                       
                       #' @name loose
                       #' @description
-                      #' 
-                      #' Returns a gNode containing the loose ends connected to the nodes in this
-                      #' gNode. If there are no loose ends, returns an empty gNode.
+                      #' Returns a GRanges containing loose ends information
+                      #' @details
+                      #' Returns info on loose ends connected to the nodes in this gNode. If there are no loose ends, returns an empty GRanges.
                       #'
                       #' @return GRanges Loose ends connected to the nodes in this gNode Object
                       loose = function()
                       {
-                        self$check
                         return(c(self$lleft, self$lright))
                       },
 
@@ -674,6 +673,9 @@ gNode = R6::R6Class("gNode",
                         return(deg)
                       },
 
+                      #' @description
+                      #' Get a GRanges containing all terminal loose ends
+                      #' @return GRanges
                       terminal = function()
                       {
                         self$check
@@ -682,35 +684,41 @@ gNode = R6::R6Class("gNode",
                             return(GRanges(seqlengths = seqlengths(self)))
                           }
                         ix = which(self$ldegree==0 | self$rdegree==0)
-                        return(self[ix]$loose)
+                        terminal.left = self[self$ldegree==0]$lleft
+                        terminal.right = self[self$rdegree==0]$lright
+                        return(c(terminal.left, terminal.right))
+                      },
+
+                      loose.degree = function(orientation)
+                      {
+                        if (!(orientation %in% c('right', 'left'))){
+                          stop('Bad orientation: "', orientation, '". orientation must be either "right", or "left"')
+                        }
+                        self$check
+                        if (!nrow(private$pgraph$edgesdt))
+                          return(0)                        
+                        op.orientation = 'right'
+                        if (orientation == 'right'){
+                            op.orientation = 'left'
+                        }
+
+                        deg = rowSums(cbind(private$pgraph$edgesdt[, sum(n1.side == orientation), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == orientation), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)
+
+                        op.deg = deg
+                        if (any(private$porientation<0)){
+                          op.deg = rowSums(cbind(private$pgraph$edgesdt[ , sum(n1.side == op.orientation), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == op.orientation), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)}
+
+                        return(pmax(0, ifelse(private$porientation>0, deg, op.deg), na.rm = TRUE))
                       },
 
                       ldegree = function()
                       {
-                        self$check
-                        if (!nrow(private$pgraph$edgesdt))
-                          return(0)                        
-
-                        ldeg = rowSums(cbind(private$pgraph$edgesdt[, sum(n1.side == 'left'), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == 'left'), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)
-
-                        rdeg = ldeg
-                        if (any(private$porientation<0)){
-                          rdeg = rowSums(cbind(private$pgraph$edgesdt[ , sum(n1.side == 'right'), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == 'right'), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)}
-
-                        return(pmax(0, ifelse(private$porientation>0, ldeg, rdeg), na.rm = TRUE))
+                        return(self$loose.degree(orientation = 'left'))
                       },
 
                       rdegree = function()
                       {
-                        self$check
-                        if (!nrow(private$pgraph$edgesdt))
-                          return(0)                        
-                        rdeg = rowSums(cbind(private$pgraph$edgesdt[, sum(n1.side == 'right'), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == 'right'), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)
-                        ldeg = rdeg
-                        if (any(private$porientation<0)){
-                          ldeg = rowSums(cbind(private$pgraph$edgesdt[, sum(n1.side == 'left'), keyby = n1][.(private$pnode.id), V1],  private$pgraph$edgesdt[, sum(n2.side == 'left'), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)}
-
-                        return(pmax(0, ifelse(private$porientation>0, rdeg, ldeg), na.rm = TRUE))
+                        return(self$loose.degree(orientation = 'right'))
                       },                        
 
                       #' @name lleft
@@ -722,18 +730,7 @@ gNode = R6::R6Class("gNode",
                       #' @return GRanges Loose ends connected to the left of the nodes in this gNode Object
                       lleft = function()
                       {
-                        self$check
-                        loose.fields = c('cn', 'loose.cn.left', 'index', 'snode.id', 'node.id')
-                        new.names = c('node.cn', 'cn', 'index', 'snode.id', 'node.id')
-                        names(new.names) = loose.fields
-                        l = gr.start(self$gr[self$gr$loose.left>0])
-                        loose.fields.keep = intersect(names(mcols(l)), loose.fields)
-                        l = l[, loose.fields.keep]
-                        names(mcols(l)) = new.names[loose.fields.keep]
-                        if (length(l) > 0){
-                            l$orientation = 'left'
-                        }
-                        return(l)
+                        return(gNode.loose(self, orientation = 'left'))
                       },
                       
                       
@@ -746,18 +743,7 @@ gNode = R6::R6Class("gNode",
                       #' @return GRanges Loose ends connected to the right of the nodes in this gNode Object
                       lright = function()
                       {
-                        self$check
-                        loose.fields = c('cn', 'loose.cn.right', 'index', 'snode.id', 'node.id')
-                        new.names = c('node.cn', 'cn', 'index', 'snode.id', 'node.id')
-                        names(new.names) = loose.fields
-                        l = gr.flipstrand(gr.end(self$gr[self$gr$loose.right>0]))
-                        loose.fields.keep = intersect(names(mcols(l)), loose.fields)
-                        l = l[, loose.fields.keep]
-                        names(mcols(l)) = new.names[loose.fields.keep]
-                        if (length(l) > 0){
-                            l$orientation = 'right'
-                        }
-                        return(l)
+                        return(gNode.loose(self, orientation = 'right'))
                       },
 
                       #' @name dist

--- a/R/gGnome.R
+++ b/R/gGnome.R
@@ -336,6 +336,28 @@ gNode = R6::R6Class("gNode",
                             message('... (', more,' additional nodes)')
                           }
                         }
+                      },
+
+                      loose.degree = function(orientation)
+                      {
+                        if (!(orientation %in% c('right', 'left'))){
+                          stop('Bad orientation: "', orientation, '". orientation must be either "right", or "left"')
+                        }
+                        self$check
+                        if (!nrow(private$pgraph$edgesdt))
+                          return(0)                        
+                        op.orientation = 'right'
+                        if (orientation == 'right'){
+                            op.orientation = 'left'
+                        }
+
+                        deg = rowSums(cbind(private$pgraph$edgesdt[, sum(n1.side == orientation), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == orientation), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)
+
+                        op.deg = deg
+                        if (any(private$porientation<0)){
+                          op.deg = rowSums(cbind(private$pgraph$edgesdt[ , sum(n1.side == op.orientation), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == op.orientation), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)}
+
+                        return(pmax(0, ifelse(private$porientation>0, deg, op.deg), na.rm = TRUE))
                       }
                     ),
                     
@@ -687,28 +709,6 @@ gNode = R6::R6Class("gNode",
                         terminal.left = self[self$ldegree==0]$lleft
                         terminal.right = self[self$rdegree==0]$lright
                         return(c(terminal.left, terminal.right))
-                      },
-
-                      loose.degree = function(orientation)
-                      {
-                        if (!(orientation %in% c('right', 'left'))){
-                          stop('Bad orientation: "', orientation, '". orientation must be either "right", or "left"')
-                        }
-                        self$check
-                        if (!nrow(private$pgraph$edgesdt))
-                          return(0)                        
-                        op.orientation = 'right'
-                        if (orientation == 'right'){
-                            op.orientation = 'left'
-                        }
-
-                        deg = rowSums(cbind(private$pgraph$edgesdt[, sum(n1.side == orientation), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == orientation), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)
-
-                        op.deg = deg
-                        if (any(private$porientation<0)){
-                          op.deg = rowSums(cbind(private$pgraph$edgesdt[ , sum(n1.side == op.orientation), keyby = n1][.(private$pnode.id), V1], private$pgraph$edgesdt[, sum(n2.side == op.orientation), keyby = n2][.(private$pnode.id), V1]), na.rm = TRUE)}
-
-                        return(pmax(0, ifelse(private$porientation>0, deg, op.deg), na.rm = TRUE))
                       },
 
                       ldegree = function()

--- a/R/gGnome.R
+++ b/R/gGnome.R
@@ -723,21 +723,37 @@ gNode = R6::R6Class("gNode",
                       lleft = function()
                       {
                         self$check
-                        return(gr.start(self$gr[self$gr$loose.left>0]))
+                        loose.fields = c('cn', 'loose.cn.left', 'index', 'snode.id', 'node.id')
+                        new.names = c('node.cn', 'cn', 'index', 'snode.id', 'node.id')
+                        names(new.names) = loose.fields
+                        l = gr.start(self$gr[self$gr$loose.left>0])
+                        loose.fields.keep = intersect(names(mcols(l)), loose.fields)
+                        l = l[, loose.fields.keep]
+                        names(mcols(l)) = new.names[loose.fields.keep]
+                        l$orientation = 'left'
+                        return(l)
                       },
                       
                       
                       #' @name lright
                       #' @description
                       #' 
-                      #' Returns a gNode containing the loose ends connected to the right of the nodes in this
-                      #' gNode. If there are no loose ends to the right, returns an empty gNode.
+                      #' Returns a GRanges containing the loose ends connected to the right of the nodes in this
+                      #' gNode. If there are no loose ends to the right, returns an empty GRanges
                       #'
                       #' @return GRanges Loose ends connected to the right of the nodes in this gNode Object
                       lright = function()
                       {
                         self$check
-                        return(gr.flipstrand(gr.end(self$gr[self$gr$loose.right>0])))
+                        loose.fields = c('cn', 'loose.cn.right', 'index', 'snode.id', 'node.id')
+                        new.names = c('node.cn', 'cn', 'index', 'snode.id', 'node.id')
+                        names(new.names) = loose.fields
+                        l = gr.flipstrand(gr.end(self$gr[self$gr$loose.right>0]))
+                        loose.fields.keep = intersect(names(mcols(l)), loose.fields)
+                        l = l[, loose.fields.keep]
+                        names(mcols(l)) = new.names[loose.fields.keep]
+                        l$orientation = 'right'
+                        return(l)
                       },
 
                       #' @name dist

--- a/R/utils.R
+++ b/R/utils.R
@@ -1876,16 +1876,21 @@ gNode.loose = function(gn, orientation)
     names(new.names) = loose.fields
     if (orientation == 'left'){
         node.ids = which(gn$gr$loose.left>0)
+        l = gr.start(gn$gr[node.ids])
     } else {
         node.ids = which(gn$gr$loose.right>0)
+        l = gr.flipstrand(gr.end(gn$gr[node.ids]))
     }
-    l = gr.start(gn$gr[node.ids])
     loose.fields.keep = intersect(names(mcols(l)), loose.fields)
     l = l[, loose.fields.keep]
     names(mcols(l)) = new.names[loose.fields.keep]
     if (length(l) > 0){
         # mark the orientation
         l$orientation = orientation
+
+        deg = gn[node.ids]$loose.degree(orientation = orientation)
+        l$degree = deg
+        l$terminal = deg == 0
     }
     return(l)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1850,3 +1850,42 @@ read_cmap = function(path, gr = TRUE, seqlevels = NULL)
 
   return(dat)
 }
+
+#' @name gNode.loose
+#' @title gNode.loose
+#'
+#' @description internal
+#'
+#' Internal utility function to get a GRanges with the right or left loose ends.
+#' This function serves as the backend of gNode$loose
+#' 
+#' @param orientation (character) either '', 'right' or 'left'. By default returns all loose ends (orientation = ''). If 'right' or 'left' returns only the loose ends that are to the right or left of nodes, accordingly.
+#' @author Alon Shaiber
+gNode.loose = function(gn, orientation)
+{
+    if (!(orientation %in% c('right', 'left'))){
+      stop('Bad orientation: "', orientation, '". orientation must be either "right", or "left"')
+    }
+    if (!inherits(gn, 'gNode')){
+      stop('Input must be a gNode, but "', class(gn), '", was provided')
+    }
+
+    gn$check
+    loose.fields = c('cn', paste0('loose.cn.', orientation), 'index', 'snode.id', 'node.id')
+    new.names = c('node.cn', 'cn', 'index', 'snode.id', 'node.id')
+    names(new.names) = loose.fields
+    if (orientation == 'left'){
+        node.ids = which(gn$gr$loose.left>0)
+    } else {
+        node.ids = which(gn$gr$loose.right>0)
+    }
+    l = gr.start(gn$gr[node.ids])
+    loose.fields.keep = intersect(names(mcols(l)), loose.fields)
+    l = l[, loose.fields.keep]
+    names(mcols(l)) = new.names[loose.fields.keep]
+    if (length(l) > 0){
+        # mark the orientation
+        l$orientation = orientation
+    }
+    return(l)
+}

--- a/tests/testthat/test_gGnome_ops.R
+++ b/tests/testthat/test_gGnome_ops.R
@@ -293,10 +293,14 @@ test_that('gNode Class Constructor/length, gGraph length/active $nodes', {
   expect_equal(gn$loose.right, TRUE)
   expect_equal(gn$degree, 1)
 
-  ##terminal, degrees
-  expect_equal(gr2dt(gn$terminal)[, start], 100)
+  ##degrees
   expect_equal(gn$ldegree, 1)
   expect_equal(gn$rdegree, 0)     
+  ## terminal (right)
+  expect_equal(gr2dt(gn$terminal)[, start], 100)
+  ## terminal (left)
+  gn5 =gNode$new(5, gg)
+  expect_equal(gr2dt(gn5$terminal)[, start], 401)
 
   ##unioning gNodes
   ##    gn2=gNode$new(2, gg)    

--- a/tests/testthat/test_gGnome_ops.R
+++ b/tests/testthat/test_gGnome_ops.R
@@ -260,6 +260,8 @@ test_that('gNode Class Constructor/length, gGraph length/active $nodes', {
   expect_error(gNode$new(-30, gg))
   expect_error(gNode$new(4, gGraph$new()))
   expect_error(gNode$new(c(1,2,-10), gg))
+
+  expect_is(gg$loose, 'GRanges')
   
   ## Testing with no snode.id
   gn = gNode$new(graph = gg)

--- a/tests/testthat/test_gGnome_ops.R
+++ b/tests/testthat/test_gGnome_ops.R
@@ -262,6 +262,8 @@ test_that('gNode Class Constructor/length, gGraph length/active $nodes', {
   expect_error(gNode$new(c(1,2,-10), gg))
 
   expect_is(gg$loose, 'GRanges')
+  expect_error(gGnome:::gNode.loose('not a gNode', 'left'))
+  expect_error(gGnome:::gNode.loose(gg$nodes, 'not left nor right'))
   
   ## Testing with no snode.id
   gn = gNode$new(graph = gg)


### PR DESCRIPTION
In this PR I introduce a change to the metadata fields for gNode$lleft and gNode$lright (which also propagates to gGraph$loose).

## Before this PR
Up until now the metadata fields for loose ends were simply inherited from the adjacent node, which means that "cn" field (if exists) actually refers to the CN of the adjacent node and not the CN of the loose end itself, which I think is not intuitive. Instead, in this commit I limited the fields passed on to the loose end to just a small subset which allows an intuitive understanding of the CN of the loose end, and since it includes the snode.id, node.id, and index of the adjacent node then it allows an easy mapping back to the nodes in order to query node metadata if needed.

Here is an example of the output of `$loose` before this PR:

```
> gg.jabba = gG(jabba = system.file('extdata/hcc1954', 'jabba.rds', package="gGnome"))
> gg.jabba$loose[1]
GRanges object with 1 range and 16 metadata columns:
      seqnames    ranges strand |        cn  start.ix    end.ix eslack.in
         <Rle> <IRanges>  <Rle> | <numeric> <integer> <integer> <numeric>
  [1]        1         1      + |         4         1        11         0
      eslack.out     loose    edges.in     edges.out   tile.id     index
       <numeric> <logical> <character>   <character> <integer> <integer>
  [1]          0     FALSE        ()-> ->2(3),->3(1)         1         1
       snode.id loose.left loose.right loose.cn.left loose.cn.right   node.id
      <numeric>  <logical>   <logical>     <numeric>      <numeric> <integer>
  [1]         1       TRUE       FALSE             0              0         1
  -------
  seqinfo: 84 sequences from an unspecified genome
```

## After this PR
```
> gg.jabba = gG(jabba = system.file('extdata/hcc1954', 'jabba.rds', package="gGnome"))
> gg.jabba$loose[1]
GRanges object with 1 range and 6 metadata columns:
      seqnames    ranges strand |   node.cn     index  snode.id        cn
         <Rle> <IRanges>  <Rle> | <numeric> <integer> <numeric> <numeric>
  [1]        1         1      + |         4         1         1         0
        node.id orientation
      <integer> <character>
  [1]         1        left
  -------
  seqinfo: 84 sequences from an unspecified genome
```

## Implications for gGnome.js
The gGraph$json function takes the "cn" field as the "weight" value that is listed in the JSON file, which means that up until now loose ends always showed the CN of the adjacent node instead of the actual CN of the loose end. Since this PR makes it so the "cn" field actually reflects the CN of the loose end then it solves this issue for gGnome.js visualization.