### PR TITLE
js.append

### DIFF
--- a/R/jsUtils.R
+++ b/R/jsUtils.R
@@ -612,7 +612,7 @@ js_path = function(outdir, append = FALSE, js.type = 'gGnome.js'){
         } else {
             is.dir.a.js.instance(outdir, js.type)
         }
-    } else (!append){
+    } else {
         # clone the repository from github
         message('Cloning the ', js.type, ' repository from github.')
         if (js.type == 'gGnome.js'){

--- a/tests/testthat/test_jsUtils.R
+++ b/tests/testthat/test_jsUtils.R
@@ -133,6 +133,18 @@ test_that('gen_js_instance', {
                 dataset_name = 'test',
                 )
 
+    # test what happens if an existing directory is provided but append is set to FALSE
+    expect_error(pgv(data.table(sample = c('mypair', 'mypair2'),
+                                  coverage = c(cov.fn, cov.fn),
+                                  graph = c(gg.rds, gg.rds)),
+                    outdir = paste0(tmpdir, '/PGV'),
+                    ref = 'hg19',
+                    cov.field = NA,
+                    append = FALSE,
+                    annotation = NULL,
+                    dataset_name = 'test',
+                    ))
+
     # test adding more data and also test what happens when the cov.field is NA (we expect a warning about skipping the coverage generation)
     expect_warning(pgv(data.table(sample = c('mypair', 'mypair2'),
                                   coverage = c(cov.fn, cov.fn),


### PR DESCRIPTION
With PR we are changing the behavior of `pgv()` and `gGnome.js` so that even if append == TRUE, but there is no clone of the repository then a clone would be generated.

So the use case for append is in case we want to make sure we are not accidentally adding data to an existing repo: so when append == FALSE then if a clone of the repo already exists then there will be an error.